### PR TITLE
Fix issue where Plucky destructively operates on input parameters.

### DIFF
--- a/lib/plucky/criteria_hash.rb
+++ b/lib/plucky/criteria_hash.rb
@@ -119,7 +119,8 @@ module Plucky
       def normalized_value(parent_key, key, value)
         case value
           when Array, Set
-            value = value.to_a.map { |v| Plucky.to_object_id(v) } if object_id?(parent_key)
+            value = value.map { |v| Plucky.to_object_id(v) } if object_id?(parent_key)
+            value = value.to_a
 
             return value if parent_key != key or [:$or, :$and].include?(key)
 


### PR DESCRIPTION
This is something I noticed in MongoMapper, while testing.  To reproduce this issue, through MongoMapper, run the following code:

``` ruby
require 'mongo_mapper'

class Bar
  include MongoMapper::Document
end

class Foo
  include MongoMapper::Document

  many :bars do
    def with_ids(ids)
      where(:id.in => [*ids])
    end
  end
end

MongoMapper.connection = ::Mongo::ReplSetConnection.new(["localhost", 27017])
MongoMapper.database = 'plucky-test'

ids = %w[4e4d72f26666d9162d000001 4e4d72fb6666d9162d000002 4e4d73006666d9162d000003]
# => ["4e4d72f26666d9162d000001", "4e4d72fb6666d9162d000002", "4e4d73006666d9162d000003"]

foo = Foo.create

foo.bars.with_ids(ids).all

ids
# => [BSON::ObjectId('4e4d72f26666d9162d000001'), BSON::ObjectId('4e4d72fb6666d9162d000002'), BSON::ObjectId('4e4d73006666d9162d000003')]
```
