### PR TITLE
Exact Array querying

### DIFF
--- a/lib/plucky/criteria_hash.rb
+++ b/lib/plucky/criteria_hash.rb
@@ -42,6 +42,20 @@ module Plucky
       source
     end
 
+    def to_query_hash
+      # Convert to final query form, just before passing to MongoDB
+      query_hash = {}
+      source.each do |key, value|
+        if value.is_a?(Hash) && value.keys[0] == :$exact
+          # Strip away the $exact operator
+          query_hash[key] = value[:$exact]
+        else
+          query_hash[key] = value
+        end
+      end
+      query_hash
+    end
+
     def merge(other)
       target = source.dup
       other.source.each_key do |key|

--- a/lib/plucky/query.rb
+++ b/lib/plucky/query.rb
@@ -53,12 +53,12 @@ module Plucky
 
     def find_each(opts={})
       query = clone.amend(opts)
-      query.collection.find(query.criteria.to_hash, query.options.to_hash)
+      query.collection.find(query.criteria.to_query_hash, query.options.to_hash)
     end
 
     def find_one(opts={})
       query = clone.amend(opts)
-      query.collection.find_one(query.criteria.to_hash, query.options.to_hash)
+      query.collection.find_one(query.criteria.to_query_hash, query.options.to_hash)
     end
 
     def find(*ids)
@@ -88,12 +88,12 @@ module Plucky
 
     def remove(opts={}, driver_opts={})
       query = clone.amend(opts)
-      query.collection.remove(query.criteria.to_hash, driver_opts)
+      query.collection.remove(query.criteria.to_query_hash, driver_opts)
     end
 
     def update(document, driver_opts={})
       query = clone
-      query.collection.update(query.criteria.to_hash, document, driver_opts)
+      query.collection.update(query.criteria.to_query_hash, document, driver_opts)
     end
 
     def count(opts={})
@@ -106,7 +106,7 @@ module Plucky
 
     def distinct(key, opts = {})
       query = clone.amend(opts)
-      query.collection.distinct(key, query.criteria.to_hash)
+      query.collection.distinct(key, query.criteria.to_query_hash)
     end
 
     def amend(opts={})
@@ -193,11 +193,11 @@ module Plucky
     end
 
     def to_hash
-      criteria.to_hash.merge(options.to_hash)
+      criteria.to_query_hash.merge(options.to_hash)
     end
 
     def explain
-      collection.find(criteria.to_hash, options.to_hash).explain
+      collection.find(criteria.to_query_hash, options.to_hash).explain
     end
 
     def inspect

--- a/test/plucky/test_query.rb
+++ b/test/plucky/test_query.rb
@@ -815,5 +815,34 @@ class QueryTest < Test::Unit::TestCase
         end
       end
     end
+    
+    context "Strip $exact operator" do
+      setup do @query = Query.new(@collection)
+        @array_collection = DB['array_test']
+        @array_a = @array_collection.insert({ :name => 'A', :items => [1, 2, 3] })
+        @array_b = @array_collection.insert({ :name => 'B', :items => [1, 2] })
+        @query = Query.new(@array_collection)
+      end
+      
+      should "work without $exact for partial match" do
+        # Test original functionality by querying { :items => [1, 2] } which should return both rows
+        @query.where(:items => [1, 2]).all.count.should == 2
+      end
+      
+      should "work without $exact for full match" do
+        # Test original functionality by querying { :items => [1, 2, 3] } which should return both rows
+        @query.where(:items => [1, 2, 3]).all.count.should == 2
+      end
+      
+      should "work with :$exact for three value array" do
+        # Test new querying with $exact operator { :items => { ;$exact => [1, 2] } } which should return one row
+        @query.where(:items => { :$exact => [1, 2, 3] }).all.count.should == 1
+      end
+      
+      should "work with :$exact for two value array" do
+        # Test new querying with $exact operator { :items => { ;$exact => [1, 2, 3] } } which should return one row
+        @query.where(:items => { :$exact => [1, 2] }).all.count.should == 1
+      end
+    end
   end
 end


### PR DESCRIPTION
This change set adds a pseudo operator "$exact" that can be used to filter MongoDB queries by exact array values.

So while MyModel.where(:items => [1, 2, 3]) results in an "$in" operator query, one can use MyModel.where(:items => { :$exact => [1, 2, 3] }) for MongoDB's default exact match query.

I originally tried to add this to normalized_value(), but since it's called multiple times to normalize the same value, it would strip away the $exact operator on the first pass and later add the $in operator again. So I added a new to_query_hash() method to be called only once, just before executing the query.
