### PR TITLE
Fix tests

### DIFF
--- a/test/plucky/test_options_hash.rb
+++ b/test/plucky/test_options_hash.rb
@@ -9,7 +9,7 @@ class OptionsHashTest < Test::Unit::TestCase
       options = OptionsHash.new(hash)
       options[:skip].should   == 1
       options[:limit].should  == 1
-      options.keys.should     == [:limit, :skip]
+      (options.keys - [:limit, :skip]).should == []
     end
 
     context "#initialize_copy" do


### PR DESCRIPTION
The array does not have to be sorted, and indeed it might report
[:skip,:limit] rather than [:limit,:skip], which would make the test fail.

Instead check that the difference between the two arrays is empty.
