### PR TITLE
Fix merge of nested criterias like

### DIFF
--- a/lib/plucky/criteria_hash.rb
+++ b/lib/plucky/criteria_hash.rb
@@ -55,7 +55,11 @@ module Plucky
 
             if value_is_hash && other_is_hash
               value.update(other_value) do |key, old_value, new_value|
-                Array(old_value).concat(Array(new_value)).uniq
+                if old_value.is_a?(Hash) && new_value.is_a?(Hash)
+                  self.class.new(old_value).merge(self.class.new(new_value)).to_hash
+                else
+                  Array(old_value).concat(Array(new_value)).uniq
+                end
               end
             elsif value_is_hash && !other_is_hash
               if modifier_key = value.keys.detect { |k| k.to_s[0, 1] == '$' }

--- a/test/plucky/test_criteria_hash.rb
+++ b/test/plucky/test_criteria_hash.rb
@@ -309,6 +309,12 @@ class CriteriaHashTest < Test::Unit::TestCase
         c1.merge(c2).should == CriteriaHash.new('$in' => [1, 2, 3])
       end
 
+      should "be able to merge two modifier hashes with hash values" do
+        c1 = CriteriaHash.new(:arr => {'$elemMatch' => {:foo => 'bar'}})
+        c2 = CriteriaHash.new(:arr => {'$elemMatch' => {:omg => 'ponies'}})
+        c1.merge(c2).should == CriteriaHash.new(:arr => {'$elemMatch' => {:foo => 'bar', :omg => 'ponies'}})
+      end
+
       should "merge matching keys with a single modifier" do
         c1 = CriteriaHash.new(:foo => {'$in' => [1, 2, 3]})
         c2 = CriteriaHash.new(:foo => {'$in' => [1, 4, 5]})


### PR DESCRIPTION
When merging criterias wich has a deeper object structure, like $elemMatch, the current implementation would transform the object into arrays. 

Improve the CriteriaHash#merge method, to allow recursively merge nested structures which also fix this problem.
