### PR TITLE
Make key normalization thread safe

### DIFF
--- a/lib/plucky/options_hash.rb
+++ b/lib/plucky/options_hash.rb
@@ -55,8 +55,7 @@ module Plucky
       }
 
       def normalized_key(key)
-        NormalizedKeys.default = key
-        NormalizedKeys[key.to_sym]
+        NormalizedKeys[key.to_sym] || key
       end
 
       def normalized_value(key, value)


### PR DESCRIPTION
Avoid setting the default on the NormalizedKeys hash so that it doesn't
cause problems in a multi-threaded environment.
