### PR TITLE
Fix for double cursor iteration, removed extraneous block binding.

### DIFF
--- a/lib/plucky/query.rb
+++ b/lib/plucky/query.rb
@@ -139,7 +139,9 @@ module Plucky
       def reverse
         clone.tap do |query|
           sort = query[:sort]
-          unless sort.nil?
+          if sort.nil?
+            query.options[:sort] = [[:_id, -1]]
+          else
             query.options[:sort] = sort.map { |s| [s[0], -s[1]] }
           end
         end

--- a/spec/plucky/query_spec.rb
+++ b/spec/plucky/query_spec.rb
@@ -249,6 +249,10 @@ describe Plucky::Query do
       described_class.new(@collection).last(:age.lte => 26, :order => :name.desc).should == @chris
     end
 
+    it "uses _id if a sort key is not specified" do
+      described_class.new(@collection).last.should == [@steve, @chris, @john].sort {|a, b| a["_id"] <=> b["_id"] }.last
+    end
+
     it "does not modify original query object" do
       query = described_class.new(@collection)
       query.last(:name => 'Steve')


### PR DESCRIPTION
Remove extraneous &block binding, remove extraneous method calls via method aliasing, fix Query#all to collect documents as it iterates them, rather than invoking to_a on the cursor post-iteration
