### PR TITLE
Fix exists?() performance using find_one().

### DIFF
--- a/lib/plucky/query.rb
+++ b/lib/plucky/query.rb
@@ -175,7 +175,7 @@ module Plucky
       end
 
       def exists?(query_options={})
-        !count(query_options).zero?
+        !!only(:_id).find_one(query_options)
       end
       alias :exist? :exists?
 


### PR DESCRIPTION
Use find_one() instead of count(), since it's faster on most datastores for large collections. Especially MongoDB, where count() can't use indexes properly.

More details in this blog post exploring performance problems traced to the original implementation:

http://blog.winfieldpeterson.com/2012/11/10/mongodb-indexing-count-unique-validations/
