### PR TITLE
do not normalize to $in operator with an empty array

### DIFF
--- a/lib/plucky/normalizers/criteria_hash_value.rb
+++ b/lib/plucky/normalizers/criteria_hash_value.rb
@@ -26,7 +26,7 @@ module Plucky
 
             if nesting_operator?(key)
               value.map  { |v| criteria_hash_class.new(v, options).to_hash }
-            elsif parent_key == key && !modifier?(key)
+            elsif parent_key == key && !modifier?(key) && !value.empty?
               # we're not nested and not the value for a symbol operator
               {:$in => value.to_a}
             else

--- a/spec/plucky/normalizers/criteria_hash_value_spec.rb
+++ b/spec/plucky/normalizers/criteria_hash_value_spec.rb
@@ -64,6 +64,12 @@ describe Plucky::Normalizers::CriteriaHashValue do
       subject.call(:foo, :foo, actual).should eq(expected)
     end
 
+    it "does not turn value to $in with an empty array value" do
+      actual = []
+      expected = []
+      subject.call(:foo, :foo, actual).should eq(expected)
+    end
+
     it "does not turn value to $in with $or key" do
       actual = [{:numbers => 1}, {:numbers => 2}]
       expected = [{:numbers => 1}, {:numbers => 2}]


### PR DESCRIPTION
illustration of issue

> db.foo.insert({ bar: [] })
> db.foo.find({ bar: { $in: [] } }).count()
> 0
> db.foo.find({ bar: [] }).count()
> 1
