### PR TITLE
Allow a paginate query to override the total_entries

### DIFF
--- a/lib/plucky/query.rb
+++ b/lib/plucky/query.rb
@@ -53,8 +53,9 @@ module Plucky
       def paginate(opts={})
         page      = opts.delete(:page)
         limit     = opts.delete(:per_page) || per_page
+        total_entries = opts.delete(:total_entries)
         query     = clone.amend(opts)
-        paginator = Pagination::Paginator.new(query.count, page, limit)
+        paginator = Pagination::Paginator.new(total_entries || query.count, page, limit)
         docs      = query.amend({
           :limit => paginator.limit,
           :skip  => paginator.skip,

--- a/spec/plucky/query_spec.rb
+++ b/spec/plucky/query_spec.rb
@@ -182,6 +182,11 @@ describe Plucky::Query do
       subject[:name].should     be_nil
     end
 
+    it "allows total_entries overrides" do
+      docs = subject.paginate(:total_entries => 1)
+      docs.total_entries.should == 1
+    end
+
     context "with options" do
       before do
         @result = @query.sort(:age).paginate(:age.gt => 27, :per_page => 10)


### PR DESCRIPTION
When using other parts of the Ruby ecosystem (like will_paginate) I've found it useful to be able to override the supposed number of elements in a paginated query. This is especially useful when the count operation is expensive and I want to use a counter cache equivalent.

This patch allows users to pass in a :total_entries option to paginate in order to override the count behavior if they have domain-local knowledge about the count and are willing to accept the risk/inconsistency inherent such optimizations.

This is more general than [other monkey patches out there](http://www.coffeepowered.net/2011/07/17/mongodb-count-and-the-big-o/) and uses an option name familiar to those who use will_paginate.
