### PR TITLE
Rspec query equality fix

### DIFF
--- a/lib/plucky/extensions/symbol.rb
+++ b/lib/plucky/extensions/symbol.rb
@@ -77,6 +77,10 @@ class SymbolOperator
   def hash
     field.hash + operator.hash
   end
+  
+  def eql?(other)
+    self == other
+  end
 
   def ==(other)
     other.class == self.class && field == other.field && operator == other.operator

--- a/spec/symbol_operator_spec.rb
+++ b/spec/symbol_operator_spec.rb
@@ -43,6 +43,15 @@ describe SymbolOperator do
       
     end
     
+    context 'eql?' do
+      
+      it 'uses #== for equality comparison' do
+        subject.should_receive(:"==").with("dummy_value")
+        subject.eql?("dummy_value")
+      end
+      
+    end
+    
     context "<=>" do
       it "returns string comparison of operator for same field, different operator" do
         (SymbolOperator.new(:foo, 'in') <=> SymbolOperator.new(:foo, 'all')).should ==  1


### PR DESCRIPTION
The following code is currently false my changes makes it return true.

```
{:test.lt => 1} == {:test.lt => 1}
```
