### PR TITLE
Replace the pagination decorator with a pagination collection to eliminate the runtime #extend, so that we aren't constantly nuking the Ruby method cache.

### DIFF
--- a/lib/plucky/pagination.rb
+++ b/lib/plucky/pagination.rb
@@ -1,4 +1,4 @@
-require 'plucky/pagination/decorator'
+require 'plucky/pagination/collection'
 require 'plucky/pagination/paginator'
 
 module Plucky

--- a/lib/plucky/pagination/collection.rb
+++ b/lib/plucky/pagination/collection.rb
@@ -1,7 +1,7 @@
 require 'forwardable'
 module Plucky
   module Pagination
-    module Decorator
+    class Collection < Array
       extend Forwardable
 
       def_delegators  :@paginator,
@@ -10,6 +10,15 @@ module Plucky
                       :previous_page, :next_page,
                       :skip,          :limit,
                       :offset,        :out_of_bounds?
+
+      def initialize(records, paginator)
+        replace records
+        @paginator = paginator
+      end
+
+      def method_missing(method, *args)
+        @query.send method, *args
+      end
 
       # Public
       def paginator(p=nil)

--- a/lib/plucky/query.rb
+++ b/lib/plucky/query.rb
@@ -60,9 +60,7 @@ module Plucky
           :skip  => paginator.skip,
         }).all
 
-        docs.extend(Pagination::Decorator)
-        docs.paginator(paginator)
-        docs
+        Pagination::Collection.new(docs, paginator)
       end
 
       def find_each(opts={})

--- a/spec/plucky/pagination/collection_spec.rb
+++ b/spec/plucky/pagination/collection_spec.rb
@@ -1,15 +1,13 @@
 require 'helper'
 
-describe Plucky::Pagination::Decorator do
-  context "Object decorated with Decorator with paginator set" do
+describe Plucky::Pagination::Collection do
+  context "Object decorated with Collection with paginator set" do
     before do
       @object    = [1, 2, 3, 4]
       @object_id = @object.object_id
       @paginator = Plucky::Pagination::Paginator.new(20, 2, 10)
-      @object.extend(described_class)
-      @object.paginator(@paginator)
     end
-    subject { @object }
+    subject { Plucky::Pagination::Collection.new(@object, @paginator) }
 
     it "knows paginator" do
       subject.paginator.should == @paginator


### PR DESCRIPTION
Similar to my MongoMapper fixes, this fix replaces the runtime `#extend` with an equivalent mechanism that avoids voiding the Ruby method cache.

We now just have a subclass of Array that can inherit the paginator and a record set. Tests pass, and no more cache nuking.
