### PR TITLE
add Range class support

### DIFF
--- a/lib/plucky/normalizers/criteria_hash_value.rb
+++ b/lib/plucky/normalizers/criteria_hash_value.rb
@@ -45,6 +45,12 @@ module Plucky
             value
           when Regexp
             Regexp.new(value)
+          when Range
+            if value.exclude_end?
+              { :$gte => value.first, :$lt  => value.last }
+            else
+              { :$gte => value.first, :$lte => value.last }
+            end
           else
             value
         end

--- a/spec/plucky/normalizers/criteria_hash_value_spec.rb
+++ b/spec/plucky/normalizers/criteria_hash_value_spec.rb
@@ -114,6 +114,24 @@ describe Plucky::Normalizers::CriteriaHashValue do
     end
   end
 
+  context 'with a range' do
+    context 'with end' do
+      it 'convert to comapre operator' do
+        actual = 1...3
+        expected = { :$gte => 1, :$lt => 3 }
+        subject.call(:numbers, :numbers, actual).should eq(expected)
+      end
+    end
+
+    context 'exclusive end' do
+      it 'convert to comapre operator' do
+        actual = 1..3
+        expected = { :$gte => 1, :$lte => 3 }
+        subject.call(:numbers, :numbers, actual).should eq(expected)
+      end
+    end
+  end
+
   context "with string object ids for string keys" do
     let(:object_id) { BSON::ObjectId.new }
 

--- a/spec/plucky/query_spec.rb
+++ b/spec/plucky/query_spec.rb
@@ -572,6 +572,14 @@ describe Plucky::Query do
       subject.where(:name => /^c/i).all.should == [@chris]
     end
 
+    it "works with range value" do
+      subject.where(:age => (28..29)).all.should =~ [@steve, @john]
+    end
+
+    it "works with exclusive end range value" do
+      subject.where(:age => (28...29)).all.should == [@john]
+    end
+
     it "updates criteria" do
       subject.
         where(:moo => 'cow').


### PR DESCRIPTION
Sometime, I want to write as like below:

```
Foo.where(created_at: Time.zone.now.all_day)
```

But, it can not. so I want to add range class support to plucky.
