### PR TITLE
add support for index hinting

### DIFF
--- a/lib/plucky/query.rb
+++ b/lib/plucky/query.rb
@@ -127,6 +127,11 @@ module Plucky
         clone.tap { |query| query.options[:fields] = *args }
       end
 
+      def hint(*fields)
+        hint_fields = fields.first.is_a?(Hash) ? fields.first : Hash[fields.map{|hint| [hint, 1]}]
+        clone.tap { |query| query.options[:hint] = hint_fields }
+      end
+
       def ignore(*args)
         set_field_inclusion(args, 0)
       end

--- a/spec/plucky/query_spec.rb
+++ b/spec/plucky/query_spec.rb
@@ -404,6 +404,29 @@ describe Plucky::Query do
     end
   end
 
+  context "#hint" do
+    before  { @query = described_class.new(@collection) }
+    subject { @query }
+
+    it "works" do
+      subject.hint(:name, :age).
+        options[:hint].
+        should == { :name => 1, :age => 1 }
+    end
+
+    it "returns new instance of query" do
+      new_query = subject.hint(:name)
+      new_query.should_not equal(subject)
+      subject[:hint].should be_nil
+    end
+
+    it "works with hash" do
+      subject.hint(:name => 1, :_id => 1).
+        options[:hint].
+        should == { :name => 1, :_id => 1 }
+    end
+  end
+
   context "#ignore" do
     before  { @query = described_class.new(@collection) }
     subject { @query }

--- a/spec/plucky_spec.rb
+++ b/spec/plucky_spec.rb
@@ -61,7 +61,7 @@ describe Plucky do
         :count, :size, :distinct,
         :last, :first, :all, :to_a,
         :exists?, :exist?, :empty?,
-        :remove,
+        :remove, :hint
       ].sort_by(&:to_s)
     end
   end


### PR DESCRIPTION
Adds the `hint` method to plucky queries.

It's useful because:

- Hinting can [speed up queries](http://grokbase.com/t/gg/mongodb-user/1268d9jjm2/supplying-hint-is-much-faster-than-letting-server-decide-for-the-same-index) particularly in the (fortunately uncommon) case of when the internal query optimizer is picking the wrong index for a query. I've noted a few circumstances where a query was crippling our service because the planner wasn't being smart enough, and needed hinting.

- Hint is a [well-documented](http://docs.mongodb.org/manual/reference/operator/meta/hint/) command for MongoDB, it's neither deprecated nor hidden. It's even [expected by Plucky](https://github.com/mongomapper/plucky/blob/master/lib/plucky/query.rb#L13]), just not realised as a proper method yet.