### PR TITLE
fix collection method_missing delegation

### DIFF
--- a/lib/plucky/pagination/collection.rb
+++ b/lib/plucky/pagination/collection.rb
@@ -17,7 +17,7 @@ module Plucky
       end
 
       def method_missing(method, *args)
-        @query.send method, *args
+        @paginator.send method, *args
       end
 
       # Public

--- a/spec/plucky/pagination/collection_spec.rb
+++ b/spec/plucky/pagination/collection_spec.rb
@@ -26,5 +26,10 @@ describe Plucky::Pagination::Collection do
       @object.size.should       == 4
       @object.select { |o| o > 2 }.should == [3, 4]
     end
+
+    it "delegates missing methods to the paginator" do
+      @paginator.should_receive(:blather_matter).with('hello', :xyz, 4)
+      subject.blather_matter('hello', :xyz, 4)
+    end
   end
 end


### PR DESCRIPTION
I stumbled on this bug by accident when I attempted to call `#all` on a Pagination::Collection object and got:

    undefined method `all' for nil:NilClass

I am not entirely sure this is what you'd want to do, but delegating missing methods to an unset instance variable is probably even less desirable/expected than delegating to the collection's paginator.

