### PR TITLE
Mongo 2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ rvm:
   - 2.0.0
   - 2.1.1
   - 2.2.4
+  - 2.3.5
+  - 2.4.1
 notifications:
   email: false
 bundler_args: --without debug guard performance

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rvm:
   - 2.0.0
   - 2.1.1
   - 2.2.4
-  - 2.3.5
+  - 2.3.4
   - 2.4.1
 notifications:
   email: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 gemspec
 
-gem 'bson_ext', '~> 1.5', :platform => :mri
 gem 'rake'
 
 group(:test) do

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ db = connection.db('test')
 collection = db['users']
 collection.remove # clear out the collection
 
-collection.insert({'_id' => 'chris', 'age' => 26, 'name' => 'Chris'})
-collection.insert({'_id' => 'steve', 'age' => 29, 'name' => 'Steve'})
-collection.insert({'_id' => 'john',  'age' => 28, 'name' => 'John'})
+collection.insert_one({'_id' => 'chris', 'age' => 26, 'name' => 'Chris'})
+collection.insert_one({'_id' => 'steve', 'age' => 29, 'name' => 'Steve'})
+collection.insert_one({'_id' => 'john',  'age' => 28, 'name' => 'John'})
 
 # initialize query with collection
 query = Plucky::Query.new(collection)

--- a/examples/query.rb
+++ b/examples/query.rb
@@ -12,9 +12,9 @@ db = connection.db('test')
 collection = db['users']
 collection.remove # clear out the collection
 
-collection.insert({'_id' => 'chris', 'age' => 26, 'name' => 'Chris'})
-collection.insert({'_id' => 'steve', 'age' => 29, 'name' => 'Steve'})
-collection.insert({'_id' => 'john',  'age' => 28, 'name' => 'John'})
+collection.insert_one({'_id' => 'chris', 'age' => 26, 'name' => 'Chris'})
+collection.insert_one({'_id' => 'steve', 'age' => 29, 'name' => 'Steve'})
+collection.insert_one({'_id' => 'john',  'age' => 28, 'name' => 'John'})
 
 # initialize query with collection
 query = Plucky::Query.new(collection)

--- a/lib/plucky.rb
+++ b/lib/plucky.rb
@@ -5,6 +5,7 @@ require 'plucky/extensions'
 require 'plucky/criteria_hash'
 require 'plucky/options_hash'
 require 'plucky/query'
+require 'plucky/transformer'
 require 'plucky/pagination'
 
 module Plucky

--- a/lib/plucky/normalizers/fields_value.rb
+++ b/lib/plucky/normalizers/fields_value.rb
@@ -11,12 +11,12 @@ module Plucky
             if value.size == 1 && value.first.is_a?(Hash)
               value.first
             else
-              value.flatten
+              value.flatten.inject({}) {|acc, field| acc.merge(field => 1)}
             end
           when Symbol
-            [value]
+            {value => 1}
           when String
-            value.split(',').map { |v| v.strip }
+            value.split(',').inject({}) { |acc, v| acc.merge(v.strip => 1) }
           else
             value
         end

--- a/lib/plucky/normalizers/options_hash_value.rb
+++ b/lib/plucky/normalizers/options_hash_value.rb
@@ -34,7 +34,7 @@ module Plucky
         }
 
         @value_normalizers = {
-          :fields => default_fields_value_normalizer,
+          :projection => default_fields_value_normalizer,
           :sort   => default_sort_value_normalizer,
           :limit  => default_limit_value_normalizer,
           :skip   => default_skip_value_normalizer,

--- a/lib/plucky/normalizers/sort_value.rb
+++ b/lib/plucky/normalizers/sort_value.rb
@@ -21,7 +21,7 @@ module Plucky
             if value.size == 1 && value[0].is_a?(String)
               normalized_sort_piece(value[0])
             else
-              value.compact.map { |v| normalized_sort_piece(v).flatten }
+              value.compact.inject({}) { |acc, v| acc.merge(normalized_sort_piece(v)) }
             end
           else
             normalized_sort_piece(value)
@@ -32,13 +32,15 @@ module Plucky
       def normalized_sort_piece(value)
         case value
           when SymbolOperator
-            [normalized_direction(value.field, value.operator)]
+            normalized_direction(value.field, value.operator)
           when String
-            value.split(',').map do |piece|
-              normalized_direction(*piece.split(' '))
+            value.split(',').inject({}) do |acc, piece|
+              acc.merge(normalized_direction(*piece.split(' ')))
             end
           when Symbol
-            [normalized_direction(value)]
+            normalized_direction(value)
+          when Array
+            Hash[*value]
           else
             value
         end
@@ -48,7 +50,7 @@ module Plucky
       def normalized_direction(field, direction=nil)
         direction ||= 'ASC'
         direction = direction.upcase == 'ASC' ? 1 : -1
-        [@key_normalizer.call(field).to_s, direction]
+        {@key_normalizer.call(field).to_s => direction}
       end
     end
   end

--- a/lib/plucky/options_hash.rb
+++ b/lib/plucky/options_hash.rb
@@ -55,7 +55,7 @@ module Plucky
 
     # Public
     def fields?
-      !self[:fields].nil?
+      !self[:projection].nil?
     end
 
     # Public
@@ -84,7 +84,8 @@ module Plucky
       @key_normalizer ||= @options.fetch(:key_normalizer) {
         Normalizers::HashKey.new({
           :order  => :sort,
-          :select => :fields,
+          :select => :projection,
+          :fields => :projection,
           :offset => :skip,
           :id     => :_id,
         })

--- a/lib/plucky/query.rb
+++ b/lib/plucky/query.rb
@@ -238,8 +238,9 @@ module Plucky
     end
 
     def cursor(&block)
-      view = @collection.find(criteria_hash, options_hash)
-      if transformer = options_hash[:transformer]
+      options = options_hash
+      view = @collection.find(criteria_hash, options)
+      if transformer = options[:transformer]
         Transformer.new(view, transformer).to_enum
       else
         view.to_enum

--- a/lib/plucky/query.rb
+++ b/lib/plucky/query.rb
@@ -105,7 +105,7 @@ module Plucky
 
       def remove(opts={}, driver_opts={})
         query = clone.amend(opts)
-        query.collection.remove(query.criteria_hash, driver_opts)
+        query.collection.find(query.criteria_hash, driver_opts).delete_many
       end
 
       def count(opts={})

--- a/lib/plucky/query.rb
+++ b/lib/plucky/query.rb
@@ -10,7 +10,7 @@ module Plucky
     # Private
     OptionKeys = Set[
       :select, :offset, :order,                         # MM
-      :fields, :skip, :limit, :sort, :hint, :snapshot,  # Ruby Driver
+      :projection, :fields, :skip, :limit, :sort, :hint, :snapshot,  # Ruby Driver
       :batch_size, :timeout, :max_scan, :return_key,    # Ruby Driver
       :transformer, :show_disk_loc, :comment, :read,    # Ruby Driver
       :tag_sets, :acceptable_latency,                   # Ruby Driver
@@ -119,9 +119,11 @@ module Plucky
         query.collection.distinct(key, query.criteria_hash)
       end
 
-      def fields(*args)
-        clone.tap { |query| query.options[:fields] = *args }
+      def projection(*args)
+        clone.tap { |query| query.options[:projection] = *args }
       end
+
+
 
       def ignore(*args)
         set_field_inclusion(args, 0)
@@ -174,6 +176,7 @@ module Plucky
       alias_method :exist?, :exists?
       alias_method :filter, :where
       alias_method :to_a,   :all
+      alias_method :fields, :projection
     end
     include DSL
 
@@ -261,7 +264,7 @@ module Plucky
     def set_field_inclusion(fields, value)
       fields_option = {}
       fields.each { |field| fields_option[symbolized_key(field)] = value }
-      clone.tap { |query| query.options[:fields] = fields_option }
+      clone.tap { |query| query.options[:projection] = fields_option }
     end
   end
 end

--- a/lib/plucky/query.rb
+++ b/lib/plucky/query.rb
@@ -79,7 +79,8 @@ module Plucky
       end
 
       def find_one(opts={})
-        find_each(opts.merge(limit: -1)).first
+        query = clone.amend(opts.merge(limit: -1))
+        query.cursor.first
       end
 
       def find(*ids)

--- a/lib/plucky/query.rb
+++ b/lib/plucky/query.rb
@@ -68,13 +68,9 @@ module Plucky
         query = clone.amend(opts)
 
         if block_given?
-          result = nil
-          query.cursor do |cursor|
-            result = cursor
-            cursor.each { |doc| yield doc }
-            cursor.rewind!
+          query.cursor.each do |doc|
+            yield doc
           end
-          result
         else
           query.cursor
         end
@@ -233,7 +229,7 @@ module Plucky
     end
 
     def cursor(&block)
-      @collection.find(criteria_hash, options_hash, &block)
+      @collection.find(criteria_hash, options_hash)
     end
 
   private

--- a/lib/plucky/query.rb
+++ b/lib/plucky/query.rb
@@ -78,7 +78,7 @@ module Plucky
 
       def find_one(opts={})
         query = clone.amend(opts)
-        query.collection.find_one(query.criteria_hash, query.options_hash)
+        query.collection.find(query.criteria_hash, query.options_hash).first
       end
 
       def find(*ids)

--- a/lib/plucky/query.rb
+++ b/lib/plucky/query.rb
@@ -72,13 +72,12 @@ module Plucky
             yield doc
           end
         else
-          query.cursor
+          query.cursor.each
         end
       end
 
       def find_one(opts={})
-        query = clone.amend(opts)
-        query.collection.find(query.criteria_hash, query.options_hash).limit(-1).first
+        find_each(opts.merge(limit: -1)).first
       end
 
       def find(*ids)

--- a/lib/plucky/query.rb
+++ b/lib/plucky/query.rb
@@ -68,11 +68,13 @@ module Plucky
         query = clone.amend(opts)
 
         if block_given?
+          cursor = query.cursor
           query.cursor.each do |doc|
             yield doc
           end
+          cursor
         else
-          query.cursor.each
+          query.cursor
         end
       end
 
@@ -239,7 +241,7 @@ module Plucky
       if transformer = options_hash[:transformer]
         Transformer.new(view, transformer).to_enum
       else
-        view
+        view.to_enum
       end
     end
 

--- a/lib/plucky/query.rb
+++ b/lib/plucky/query.rb
@@ -235,7 +235,12 @@ module Plucky
     end
 
     def cursor(&block)
-      @collection.find(criteria_hash, options_hash)
+      view = @collection.find(criteria_hash, options_hash)
+      if transformer = options_hash[:transformer]
+        Transformer.new(view.each, transformer).to_enum
+      else
+        view
+      end
     end
 
   private

--- a/lib/plucky/query.rb
+++ b/lib/plucky/query.rb
@@ -237,7 +237,7 @@ module Plucky
     def cursor(&block)
       view = @collection.find(criteria_hash, options_hash)
       if transformer = options_hash[:transformer]
-        Transformer.new(view.each, transformer).to_enum
+        Transformer.new(view, transformer).to_enum
       else
         view
       end

--- a/lib/plucky/query.rb
+++ b/lib/plucky/query.rb
@@ -68,19 +68,19 @@ module Plucky
         query = clone.amend(opts)
 
         if block_given?
-          cursor = query.cursor
-          cursor.each do |doc|
+          enumerator = query.enumerator
+          enumerator.each do |doc|
             yield doc
           end
-          cursor
+          enumerator
         else
-          query.cursor
+          query.enumerator
         end
       end
 
       def find_one(opts={})
         query = clone.amend(opts.merge(limit: -1))
-        query.cursor.first
+        query.enumerator.first
       end
 
       def find(*ids)
@@ -112,7 +112,7 @@ module Plucky
 
       def count(opts={})
         query = clone.amend(opts)
-        cursor = query.cursor
+        cursor = query.view
         cursor.count
       end
 
@@ -237,10 +237,12 @@ module Plucky
       @options.to_hash
     end
 
-    def cursor(&block)
-      options = options_hash
-      view = @collection.find(criteria_hash, options)
-      if transformer = options[:transformer]
+    def view
+      @collection.find(criteria_hash, options_hash)
+    end
+
+    def enumerator
+      if transformer = options_hash[:transformer]
         Transformer.new(view, transformer).to_enum
       else
         view.to_enum

--- a/lib/plucky/query.rb
+++ b/lib/plucky/query.rb
@@ -179,7 +179,11 @@ module Plucky
 
     def update(document, driver_opts={})
       query = clone
-      query.collection.update(query.criteria_hash, document, driver_opts)
+      if driver_opts[:multi]
+        query.collection.find(query.criteria_hash).update_many(document, driver_opts)
+      else
+        query.collection.find(query.criteria_hash).update_one(document, driver_opts)
+      end
     end
 
     def amend(opts={})

--- a/lib/plucky/query.rb
+++ b/lib/plucky/query.rb
@@ -78,7 +78,7 @@ module Plucky
 
       def find_one(opts={})
         query = clone.amend(opts)
-        query.collection.find(query.criteria_hash, query.options_hash).first
+        query.collection.find(query.criteria_hash, query.options_hash).limit(-1).first
       end
 
       def find(*ids)

--- a/lib/plucky/query.rb
+++ b/lib/plucky/query.rb
@@ -69,7 +69,7 @@ module Plucky
 
         if block_given?
           cursor = query.cursor
-          query.cursor.each do |doc|
+          cursor.each do |doc|
             yield doc
           end
           cursor

--- a/lib/plucky/transformer.rb
+++ b/lib/plucky/transformer.rb
@@ -1,0 +1,14 @@
+module Plucky
+  class Transformer
+    def initialize(iterable, transformer)
+      @iterable = iterable
+      @transformer = transformer
+    end
+
+    def each
+      @iterable.each do |doc|
+        yield @transformer.call(doc)
+      end
+    end
+  end
+end

--- a/lib/plucky/transformer.rb
+++ b/lib/plucky/transformer.rb
@@ -1,12 +1,12 @@
 module Plucky
   class Transformer
-    def initialize(iterable, transformer)
-      @iterable = iterable
+    def initialize(view, transformer)
+      @view = view
       @transformer = transformer
     end
 
     def each
-      @iterable.each do |doc|
+      @view.each do |doc|
         yield @transformer.call(doc)
       end
     end

--- a/plucky.gemspec
+++ b/plucky.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'mongo', '~> 1.5'
+  s.add_dependency 'mongo', '~> 2.0'
 end

--- a/spec/functional/options_hash_spec.rb
+++ b/spec/functional/options_hash_spec.rb
@@ -6,13 +6,13 @@ describe Plucky::OptionsHash do
   describe "#[]=" do
     it "changes order to sort" do
       subject[:order] = "foo asc"
-      subject[:sort].should == [["foo", 1]]
+      subject[:sort].should == {"foo" => 1}
       subject[:order].should be_nil
     end
 
     it "changes sort(id) to sort(_id)" do
       subject[:sort] = "id asc"
-      subject[:sort].should == [["_id", 1]]
+      subject[:sort].should == {"_id" => 1}
     end
 
     it "changes select to fields" do
@@ -35,7 +35,7 @@ describe Plucky::OptionsHash do
 
     it "does not change the sort field" do
       subject[:order] = :order.asc
-      subject[:sort].should == [["order", 1]]
+      subject[:sort].should == {"order" => 1}
     end
   end
 end

--- a/spec/functional/options_hash_spec.rb
+++ b/spec/functional/options_hash_spec.rb
@@ -17,7 +17,7 @@ describe Plucky::OptionsHash do
 
     it "changes select to fields" do
       subject[:select] = [:foo]
-      subject[:fields].should == [:foo]
+      subject[:projection].should == {:foo => 1}
       subject[:select].should be_nil
     end
 

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -18,8 +18,8 @@ Log = Logger.new(File.join(log_dir, 'test.log'))
 LogBuddy.init :logger => Log
 
 port = ENV.fetch "BOXEN_MONGODB_PORT", 27017
-connection = Mongo::MongoClient.new('127.0.0.1', port.to_i, :logger => Log)
-DB = connection.db('test')
+connection = Mongo::Client.new(["127.0.0.1:#{port.to_i}"], :logger => Log)
+DB = connection.use('test').database
 
 RSpec.configure do |config|
   config.filter_run :focused => true
@@ -30,13 +30,13 @@ RSpec.configure do |config|
   config.before(:suite) do
     DB.collections.reject { |collection|
       collection.name =~ /system\./
-    }.map(&:drop_indexes)
+    }.each { |collection| collection.indexes.drop_all}
   end
 
   config.before(:each) do
     DB.collections.reject { |collection|
       collection.name =~ /system\./
-    }.map(&:remove)
+    }.map(&:drop)
   end
 end
 

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -26,6 +26,9 @@ RSpec.configure do |config|
   config.alias_example_to :fit, :focused => true
   config.alias_example_to :xit, :pending => true
   config.run_all_when_everything_filtered = true
+  
+  config.expect_with(:rspec) { |c| c.syntax = [:should, :expect] }
+  config.mock_with(:rspec) { |c| c.syntax = :should }
 
   config.before(:suite) do
     DB.collections.reject { |collection|

--- a/spec/plucky/normalizers/fields_value_spec.rb
+++ b/spec/plucky/normalizers/fields_value_spec.rb
@@ -15,7 +15,7 @@ describe Plucky::Normalizers::FieldsValue do
   end
 
   it "works with array" do
-    subject.call(['one', 'two']).should eq(['one', 'two'])
+    subject.call(['one', 'two']).should eq({'one' => 1, 'two' => 1})
   end
 
   # Ruby 1.9.x was sending array [{:age => 20}], instead of hash.
@@ -24,15 +24,15 @@ describe Plucky::Normalizers::FieldsValue do
   end
 
   it "flattens multi-dimensional array" do
-    subject.call([[:one, :two]]).should eq([:one, :two])
+    subject.call([[:one, :two]]).should eq({:one => 1, :two => 1})
   end
 
   it "works with symbol" do
-    subject.call(:one).should eq([:one])
+    subject.call(:one).should eq({:one => 1})
   end
 
   it "works with array of symbols" do
-    subject.call([:one, :two]).should eq([:one, :two])
+    subject.call([:one, :two]).should eq({:one => 1, :two => 1})
   end
 
   it "works with hash" do
@@ -40,6 +40,6 @@ describe Plucky::Normalizers::FieldsValue do
   end
 
   it "converts comma separated list to array" do
-    subject.call('one, two').should eq(['one', 'two'])
+    subject.call('one, two').should eq({'one' => 1, 'two' => 1})
   end
 end

--- a/spec/plucky/normalizers/sort_value_spec.rb
+++ b/spec/plucky/normalizers/sort_value_spec.rb
@@ -31,68 +31,68 @@ describe Plucky::Normalizers::SortValue do
   end
 
   it "converts single ascending field (string)" do
-    subject.call('foo asc').should eq([['foo', 1]])
-    subject.call('foo ASC').should eq([['foo', 1]])
+    subject.call('foo asc').should eq({'foo' => 1})
+    subject.call('foo ASC').should eq({'foo' => 1})
   end
 
   it "converts single descending field (string)" do
-    subject.call('foo desc').should eq([['foo', -1]])
-    subject.call('foo DESC').should eq([['foo', -1]])
+    subject.call('foo desc').should eq({'foo' => -1})
+    subject.call('foo DESC').should eq({'foo' => -1})
   end
 
   it "converts multiple fields (string)" do
-    subject.call('foo desc, bar asc').should eq([['foo', -1], ['bar', 1]])
+    subject.call('foo desc, bar asc').should eq({'foo' => -1, 'bar' => 1})
   end
 
   it "converts multiple fields and default no direction to ascending (string)" do
-    subject.call('foo desc, bar, baz').should eq([['foo', -1], ['bar', 1], ['baz', 1]])
+    subject.call('foo desc, bar, baz').should eq({'foo' => -1, 'bar' => 1, 'baz' => 1})
   end
 
   it "converts symbol" do
-    subject.call(:name).should eq([['name', 1]])
+    subject.call(:name).should eq({'name' => 1})
   end
 
   it "converts operator" do
-    subject.call(:foo.desc).should eq([['foo', -1]])
+    subject.call(:foo.desc).should eq({'foo' => -1})
   end
 
   it "converts array of operators" do
-    subject.call([:foo.desc, :bar.asc]).should eq([['foo', -1], ['bar', 1]])
+    subject.call([:foo.desc, :bar.asc]).should eq({'foo' => -1, 'bar' => 1})
   end
 
   it "converts array of symbols" do
-    subject.call([:first_name, :last_name]).should eq([['first_name', 1], ['last_name', 1]])
+    subject.call([:first_name, :last_name]).should eq({'first_name' => 1, 'last_name' => 1})
   end
 
   it "works with array and one string element" do
-    subject.call(['foo, bar desc']).should eq([['foo', 1], ['bar', -1]])
+    subject.call(['foo, bar desc']).should eq({'foo' => 1, 'bar' => -1})
   end
 
   it "works with array of single array" do
-    subject.call([['foo', -1]]).should eq([['foo', -1]])
+    subject.call([['foo', -1]]).should eq({'foo' => -1})
   end
 
   it "works with array of multiple arrays" do
-    subject.call([['foo', -1], ['bar', 1]]).should eq([['foo', -1], ['bar', 1]])
+    subject.call([['foo', -1], ['bar', 1]]).should eq({'foo' => -1, 'bar' => 1})
   end
 
   it "compacts nil values in array" do
-    subject.call([nil, :foo.desc]).should eq([['foo', -1]])
+    subject.call([nil, :foo.desc]).should eq({'foo' => -1})
   end
 
   it "converts array with mix of values" do
-    subject.call([:foo.desc, 'bar']).should eq([['foo', -1], ['bar', 1]])
+    subject.call([:foo.desc, 'bar']).should eq({'foo' => -1, 'bar' => 1})
   end
 
   it "converts keys based on key normalizer" do
-    subject.call([:id.asc]).should eq([['_id', 1]])
+    subject.call([:id.asc]).should eq({'_id' => 1})
   end
 
   it "doesn't convert keys like :sort to :order via key normalizer" do
-    subject.call(:order.asc).should eq([['order', 1]])
+    subject.call(:order.asc).should eq({'order' => 1})
   end
 
   it "converts string with $natural correctly" do
-    subject.call('$natural desc').should eq([['$natural', -1]])
+    subject.call('$natural desc').should eq({'$natural' => -1})
   end
 end

--- a/spec/plucky/options_hash_spec.rb
+++ b/spec/plucky/options_hash_spec.rb
@@ -3,7 +3,7 @@ require 'helper'
 describe Plucky::OptionsHash do
   describe "#initialize_copy" do
     before do
-      @original = described_class.new(:fields => {:name => true}, :sort => :name, :limit => 10)
+      @original = described_class.new(:projection => {:name => true}, :sort => :name, :limit => 10)
       @cloned   = @original.clone
     end
 
@@ -12,7 +12,7 @@ describe Plucky::OptionsHash do
     end
 
     it "clones duplicable? values" do
-      @cloned[:fields].should_not equal(@original[:fields])
+      @cloned[:projection].should_not equal(@original[:projection])
       @cloned[:sort].should_not equal(@original[:sort])
     end
   end

--- a/spec/plucky/query_spec.rb
+++ b/spec/plucky/query_spec.rb
@@ -737,7 +737,7 @@ describe Plucky::Query do
     end
 
     {
-      :fields     => ['foo'],
+      :projection => {'foo' => 1},
       :sort       => {'foo' => 1},
       :hint       => '',
       :skip       => 0,
@@ -754,7 +754,7 @@ describe Plucky::Query do
 
     it "knows select is an option and remove it from options" do
       query = described_class.new(@collection, :select => 'foo')
-      query.options[:fields].should == ['foo']
+      query.options[:projection].should == {'foo' => 1}
       query.criteria.keys.should_not include(:select)
       query.options.keys.should_not  include(:select)
     end
@@ -785,7 +785,7 @@ describe Plucky::Query do
       query.criteria.source.should eq(:foo => 'bar', :baz => true)
       query.options.source.should eq({
         :sort   => {"foo" => 1},
-        :fields => ['foo', 'baz'],
+        :projection => {'foo' => 1, 'baz' => 1},
         :limit  => 10,
         :skip   => 10,
       })

--- a/spec/plucky/query_spec.rb
+++ b/spec/plucky/query_spec.rb
@@ -279,6 +279,11 @@ describe Plucky::Query do
       query.count(:name => 'Steve')
       query[:name].should be_nil
     end
+
+    it 'counts the result set and not the enumerator' do
+      described_class.new(@collection).limit(1).count.should == 3
+    end
+    
   end
 
   context "#size" do

--- a/spec/plucky/query_spec.rb
+++ b/spec/plucky/query_spec.rb
@@ -489,23 +489,23 @@ describe Plucky::Query do
     end
 
     it "works with symbol operators" do
-      subject.sort(:foo.asc, :bar.desc).options[:sort].should == [['foo', 1], ['bar', -1]]
+      subject.sort(:foo.asc, :bar.desc).options[:sort].should == {"foo" => 1, "bar" => -1}
     end
 
     it "works with string" do
-      subject.sort('foo, bar desc').options[:sort].should == [['foo', 1], ['bar', -1]]
+      subject.sort('foo, bar desc').options[:sort].should == {"foo" => 1, "bar" => -1}
     end
 
     it "works with just a symbol" do
-      subject.sort(:foo).options[:sort].should == [['foo', 1]]
+      subject.sort(:foo).options[:sort].should == {"foo" => 1}
     end
 
     it "works with symbol descending" do
-      subject.sort(:foo.desc).options[:sort].should == [['foo', -1]]
+      subject.sort(:foo.desc).options[:sort].should == {"foo" => -1}
     end
 
     it "works with multiple symbols" do
-      subject.sort(:foo, :bar).options[:sort].should == [['foo', 1], ['bar', 1]]
+      subject.sort(:foo, :bar).options[:sort].should == {"foo" => 1, "bar" => 1}
     end
 
     it "returns new instance of query" do
@@ -515,8 +515,8 @@ describe Plucky::Query do
     end
 
     it "is aliased to order" do
-      subject.order(:foo).options[:sort].should       == [['foo', 1]]
-      subject.order(:foo, :bar).options[:sort].should == [['foo', 1], ['bar', 1]]
+      subject.order(:foo).options[:sort].should       == {"foo" => 1}
+      subject.order(:foo, :bar).options[:sort].should == {"foo" => 1, "bar" => 1}
     end
   end
 
@@ -536,20 +536,20 @@ describe Plucky::Query do
 
     it "reverses the sort order" do
       subject.sort('foo asc, bar desc').
-        reverse.options[:sort].should == [['foo', -1], ['bar', 1]]
+        reverse.options[:sort].should == {"foo" => -1, "bar" => 1}
     end
 
     it "returns new instance of query" do
       sorted_query = subject.sort(:name)
       new_query = sorted_query.reverse
       new_query.should_not equal(sorted_query)
-      sorted_query[:sort].should == [['name', 1]]
+      sorted_query[:sort].should == {'name' => 1}
     end
   end
 
   context "#amend" do
     it "normalizes and update options" do
-      described_class.new(@collection).amend(:order => :age.desc).options[:sort].should == [['age', -1]]
+      described_class.new(@collection).amend(:order => :age.desc).options[:sort].should == {'age' => -1}
     end
 
     it "works with simple stuff" do
@@ -738,7 +738,7 @@ describe Plucky::Query do
 
     {
       :fields     => ['foo'],
-      :sort       => [['foo', 1]],
+      :sort       => {'foo' => 1},
       :hint       => '',
       :skip       => 0,
       :limit      => 0,
@@ -761,7 +761,7 @@ describe Plucky::Query do
 
     it "knows order is an option and remove it from options" do
       query = described_class.new(@collection, :order => 'foo')
-      query.options[:sort].should == [['foo', 1]]
+      query.options[:sort].should == {'foo' => 1}
       query.criteria.keys.should_not include(:order)
       query.options.keys.should_not  include(:order)
     end
@@ -777,14 +777,14 @@ describe Plucky::Query do
       query = described_class.new(@collection, {
         :foo    => 'bar',
         :baz    => true,
-        :sort   => [['foo', 1]],
+        :sort   => {"foo" => 1},
         :fields => ['foo', 'baz'],
         :limit  => 10,
         :skip   => 10,
       })
       query.criteria.source.should eq(:foo => 'bar', :baz => true)
       query.options.source.should eq({
-        :sort   => [['foo', 1]],
+        :sort   => {"foo" => 1},
         :fields => ['foo', 'baz'],
         :limit  => 10,
         :skip   => 10,

--- a/spec/plucky/query_spec.rb
+++ b/spec/plucky/query_spec.rb
@@ -611,7 +611,7 @@ describe Plucky::Query do
 
   context "#empty?" do
     it "returns true if empty" do
-      @collection.remove
+      @collection.drop
       described_class.new(@collection).should be_empty
     end
 

--- a/spec/plucky/query_spec.rb
+++ b/spec/plucky/query_spec.rb
@@ -128,7 +128,7 @@ describe Plucky::Query do
     end
 
     it "normalizes if using object id" do
-      id = @collection.insert_one(:name => 'Frank')
+      id = @collection.insert_one(:name => 'Frank').inserted_id
       @query.object_ids([:_id])
       doc = @query.find(id.to_s)
       doc['name'].should == 'Frank'

--- a/spec/plucky/query_spec.rb
+++ b/spec/plucky/query_spec.rb
@@ -57,7 +57,7 @@ describe Plucky::Query do
   context "#find_each" do
     it "returns a cursor" do
       cursor = described_class.new(@collection).find_each
-      cursor.should be_instance_of(Mongo::Cursor)
+      cursor.should be_instance_of(Enumerator)
     end
 
     it "works with and normalize criteria" do
@@ -78,8 +78,8 @@ describe Plucky::Query do
 
     it "is Ruby-like and returns a reset cursor if a block is given" do
       cursor = described_class.new(@collection).find_each {}
-      cursor.should be_instance_of(Mongo::Cursor)
-      cursor.next.should be_instance_of(Hash)
+      cursor.should be_instance_of(Enumerator)
+      cursor.next.should be_kind_of(Hash)
     end
   end
 
@@ -849,5 +849,16 @@ describe Plucky::Query do
         result.should be_instance_of(@user_class)
       end
     end
+
+    it "works with block form of find_each" do
+      results = []
+      @query.find_each do |doc|
+        results << doc
+      end
+      results.each do |result|
+        result.should be_instance_of(@user_class)
+      end
+    end
+
   end
 end

--- a/spec/plucky/query_spec.rb
+++ b/spec/plucky/query_spec.rb
@@ -672,7 +672,7 @@ describe Plucky::Query do
     it "returns a working enumerator" do
       query = described_class.new(@collection)
       query.each.methods.map(&:to_sym).include?(:group_by).should be(true)
-      query.each.next.should be_instance_of(Hash)
+      query.each.next.should be_instance_of(BSON::Document)
     end
   end
 

--- a/spec/plucky/query_spec.rb
+++ b/spec/plucky/query_spec.rb
@@ -2,9 +2,9 @@ require 'helper'
 
 describe Plucky::Query do
   before do
-    @chris      = BSON::OrderedHash['_id', 'chris', 'age', 26, 'name', 'Chris']
-    @steve      = BSON::OrderedHash['_id', 'steve', 'age', 29, 'name', 'Steve']
-    @john       = BSON::OrderedHash['_id', 'john',  'age', 28, 'name', 'John']
+    @chris      = Hash['_id', 'chris', 'age', 26, 'name', 'Chris']
+    @steve      = Hash['_id', 'steve', 'age', 29, 'name', 'Steve']
+    @john       = Hash['_id', 'john',  'age', 28, 'name', 'John']
     @collection = DB['users']
     @collection.insert(@chris)
     @collection.insert(@steve)
@@ -79,7 +79,7 @@ describe Plucky::Query do
     it "is Ruby-like and returns a reset cursor if a block is given" do
       cursor = described_class.new(@collection).find_each {}
       cursor.should be_instance_of(Mongo::Cursor)
-      cursor.next.should be_instance_of(BSON::OrderedHash)
+      cursor.next.should be_instance_of(Hash)
     end
   end
 

--- a/spec/plucky/query_spec.rb
+++ b/spec/plucky/query_spec.rb
@@ -203,6 +203,29 @@ describe Plucky::Query do
     end
   end
 
+  context "#view" do
+    it 'returns a mongo::collection::view' do
+      described_class.new(@collection).view.should be_a(Mongo::Collection::View)
+    end
+
+    it 'converts criteria into the view' do
+      view = described_class.new(@collection).where(:name => "bob").view
+      view.filter.should == {"name" => "bob"}
+    end
+
+    it "converts read option symbol to a server selector" do
+      view = described_class.new(@collection, :read => :secondary_preferred).view
+      view.read.should be_a(Mongo::ServerSelector::SecondaryPreferred)
+    end
+
+    it "converts read option hash to a server selector" do
+      view = described_class.new(@collection, :read => {:mode =>:secondary_preferred}).view
+      view.read.should be_a(Mongo::ServerSelector::SecondaryPreferred)
+    end
+  end
+
+
+
   context "#all" do
     it "works with no arguments" do
       docs = described_class.new(@collection).all

--- a/spec/plucky/query_spec.rb
+++ b/spec/plucky/query_spec.rb
@@ -6,9 +6,9 @@ describe Plucky::Query do
     @steve      = Hash['_id', 'steve', 'age', 29, 'name', 'Steve']
     @john       = Hash['_id', 'john',  'age', 28, 'name', 'John']
     @collection = DB['users']
-    @collection.insert(@chris)
-    @collection.insert(@steve)
-    @collection.insert(@john)
+    @collection.insert_one(@chris)
+    @collection.insert_one(@steve)
+    @collection.insert_one(@john)
   end
 
   context "#initialize" do
@@ -128,7 +128,7 @@ describe Plucky::Query do
     end
 
     it "normalizes if using object id" do
-      id = @collection.insert(:name => 'Frank')
+      id = @collection.insert_one(:name => 'Frank')
       @query.object_ids([:_id])
       doc = @query.find(id.to_s)
       doc['name'].should == 'Frank'
@@ -290,8 +290,8 @@ describe Plucky::Query do
   context "#distinct" do
     before do
       # same age as John
-      @mark = BSON::OrderedHash['_id', 'mark', 'age', 28, 'name', 'Mark']
-      @collection.insert(@mark)
+      @mark = Hash['_id', 'mark', 'age', 28, 'name', 'Mark']
+      @collection.insert_one(@mark)
     end
 
     it "works with just a key" do
@@ -672,7 +672,7 @@ describe Plucky::Query do
     it "returns a working enumerator" do
       query = described_class.new(@collection)
       query.each.methods.map(&:to_sym).include?(:group_by).should be(true)
-      query.each.next.should be_instance_of(BSON::OrderedHash)
+      query.each.next.should be_instance_of(Hash)
     end
   end
 

--- a/spec/plucky_spec.rb
+++ b/spec/plucky_spec.rb
@@ -56,7 +56,7 @@ describe Plucky do
         :where, :filter,
         :sort, :order, :reverse,
         :paginate, :per_page, :limit, :skip, :offset,
-        :fields, :ignore, :only,
+        :fields, :projection, :ignore, :only,
         :each, :find_each, :find_one, :find,
         :count, :size, :distinct,
         :last, :first, :all, :to_a,


### PR DESCRIPTION
Still a work in progress.

I've got the test suite mostly passing (6 failures). The remaining failures are around:
- the transformer stuff doesn't exist ing mongo 2.x
- return value of find_each - (to be honest, not sure what it should be doing)

I'm also uncertain as to what degree we should be preserving backwards compatibility - e.g. with mongo 2.x you need pass a projection option rather than a fields option. Should the old name still work with plucky? Either way there is still a lot of breakage, since a lot of the driver methods & behaviour leak through plucky.

The other think is whether plucky is even needed for MM anymore ? The point of plucky seems at least in part to put a fluent interface on top of the mongo driver, but mongo 2.x already has a fluent interface. Patching up plucky is probably useful, at least as an intermediate step.

Feedback etc. welcome!
