### PR TITLE
Add find_in_batches method

### DIFF
--- a/lib/plucky/query.rb
+++ b/lib/plucky/query.rb
@@ -64,15 +64,9 @@ module Plucky
         Pagination::Collection.new(docs, paginator)
       end
 
-      def find_in_batches(opts={})
-        batch_size = opts[:batch_size] || 1000
-        if block_given?
-          find_each(opts).each_slice(batch_size) do |documents|
-            yield documents
-          end
-        else
-          find_each(opts).each_slice(batch_size)
-        end
+      def find_in_batches(opts={}, &block)
+        opts[:batch_size] = opts[:batch_size] || 1000
+        find_each(opts).each_slice(opts[:batch_size], &block)
       end
 
       def find_each(opts={})

--- a/lib/plucky/query.rb
+++ b/lib/plucky/query.rb
@@ -64,6 +64,17 @@ module Plucky
         Pagination::Collection.new(docs, paginator)
       end
 
+      def find_in_batches(opts={})
+        batch_size = opts[:batch_size] || 1000
+        if block_given?
+          find_each(opts).each_slice(batch_size) do |documents|
+            yield documents
+          end
+        else
+          find_each(opts).each_slice(batch_size)
+        end
+      end
+
       def find_each(opts={})
         query = clone.amend(opts)
 

--- a/spec/plucky/query_spec.rb
+++ b/spec/plucky/query_spec.rb
@@ -54,6 +54,29 @@ describe Plucky::Query do
     end
   end
 
+  context "#find_in_batches" do
+    it "returns an enumerator" do
+      documents_arrays = described_class.new(@collection).find_in_batches
+      documents_arrays.should be_instance_of(Enumerator)
+    end
+
+    it "works with and normalize criteria" do
+      documents_arrays = described_class.new(@collection).find_in_batches(:id.in => ['john'])
+      documents_arrays.first.should == [@john]
+    end
+
+    it "works with and normalize options" do
+      documents_arrays = described_class.new(@collection).find_in_batches(:order => :name.asc)
+      documents_arrays.to_a.flatten.should == [@chris, @john, @steve]
+    end
+
+    it "yields elements to a block if given" do
+      yielded_elements = Set.new
+      described_class.new(@collection).find_in_batches(batch_size: 2, order: :name.asc) { |doc| yielded_elements << doc }
+      yielded_elements.should == [[@chris, @john], [@steve]].to_set
+    end
+  end
+
   context "#find_each" do
     it "returns a cursor" do
       cursor = described_class.new(@collection).find_each

--- a/spec/plucky_spec.rb
+++ b/spec/plucky_spec.rb
@@ -57,7 +57,7 @@ describe Plucky do
         :sort, :order, :reverse,
         :paginate, :per_page, :limit, :skip, :offset,
         :fields, :ignore, :only,
-        :each, :find_each, :find_one, :find,
+        :each, :find_in_batches, :find_each, :find_one, :find,
         :count, :size, :distinct,
         :last, :first, :all, :to_a,
         :exists?, :exist?, :empty?,


### PR DESCRIPTION
Hello @jnunemaker .

I sometimes want to use `Plucky#find_each` as like ActiveRecord's [`find_in_batches`](http://api.rubyonrails.org/classes/ActiveRecord/Batches.html#method-i-find_in_batches) and I substitute `find_each(opts).each_slice(batch_size)` for that.

But I thought that it's useful for also other mongomapper users to add the `find_in_batches` method to plucky queries.
I would appreciate it if you would review this, thank you.
