### PR TITLE
Add Ruby 3.3 to CI matrix

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -21,13 +21,14 @@ jobs:
           - 3.0.6
           - 3.1.4
           - 3.2.2
+          - 3.3.0
         mongo-image:
           - mongo:4.4
         include:
-          - { "ruby-version": 3.2.2, "mongo-image": "mongo:4.2" }
-          - { "ruby-version": 3.2.2, "mongo-image": "mongo:5.0" }
-          - { "ruby-version": 3.2.2, "mongo-image": "mongo:6.0" }
-          - { "ruby-version": 3.2.2, "mongo-image": "mongo:7.0" }
+          - { "ruby-version": 3.3.0, "mongo-image": "mongo:4.2" }
+          - { "ruby-version": 3.3.0, "mongo-image": "mongo:5.0" }
+          - { "ruby-version": 3.3.0, "mongo-image": "mongo:6.0" }
+          - { "ruby-version": 3.3.0, "mongo-image": "mongo:7.0" }
     services:
       mongo:
         image: ${{ matrix.mongo-image }}


### PR DESCRIPTION
I added Ruby 3.3.0 to the CI matrix.

There are no changes in plucky's implementation. So we don't have to release a new version to support Ruby 3.3.

As a side note, we have the following warnings while running spec against Ruby 3.3. We can see them [here](https://github.com/mongomapper/plucky/actions/runs/7340516357/job/19986643910?pr=54). According to [the release note](https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/#:~:text=RubyGems%20and%20Bundler%20warn%20if%20users%20do%20require%20the%20following%20gems%20without%20adding%20them%20to%20Gemfile%20or%20gemspec.%20This%20is%20because%20they%20will%20become%20the%20bundled%20gems%20in%20the%20future%20version%20of%20Ruby.), it is just for mongo gem and we don't have to do anything to resolve it.

> /opt/hostedtoolcache/Ruby/3.3.0/x64/lib/ruby/gems/3.3.0/gems/mongo-2.19.3/lib/mongo.rb:18: warning: base64 was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec. Also contact author of mongo-2.19.3 to add base64 into its gemspec.
/opt/hostedtoolcache/Ruby/3.3.0/x[6](https://github.com/mongomapper/plucky/actions/runs/7340516357/job/19986643910?pr=54#step:6:7)4/lib/ruby/gems/3.3.0/gems/bson-4.15.0/lib/bson/decimal128.rb:16: warning: bigdecimal was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add bigdecimal to your Gemfile or gemspec. Also contact author of bson-4.15.0 to add bigdecimal into its gemspec.

