### PR TITLE
Omit Ruby patch version in CI matrix

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -14,21 +14,21 @@ jobs:
       matrix:
         ruby-version:
           - jruby
-          - 2.4.10
-          - 2.5.9
-          - 2.6.10
-          - 2.7.8
-          - 3.0.6
-          - 3.1.4
-          - 3.2.2
-          - 3.3.0
+          - 2.4
+          - 2.5
+          - 2.6
+          - 2.7
+          - 3.0
+          - 3.1
+          - 3.2
+          - 3.3
         mongo-image:
           - mongo:4.4
         include:
-          - { "ruby-version": 3.3.0, "mongo-image": "mongo:4.2" }
-          - { "ruby-version": 3.3.0, "mongo-image": "mongo:5.0" }
-          - { "ruby-version": 3.3.0, "mongo-image": "mongo:6.0" }
-          - { "ruby-version": 3.3.0, "mongo-image": "mongo:7.0" }
+          - { "ruby-version": 3.3, "mongo-image": "mongo:4.2" }
+          - { "ruby-version": 3.3, "mongo-image": "mongo:5.0" }
+          - { "ruby-version": 3.3, "mongo-image": "mongo:6.0" }
+          - { "ruby-version": 3.3, "mongo-image": "mongo:7.0" }
     services:
       mongo:
         image: ${{ matrix.mongo-image }}


### PR DESCRIPTION
ruby/setup-ruby interprets a short version like '2.6' as the latest release corresponding to that version (e.g., 2.6.10).
https://github.com/ruby/setup-ruby?tab=readme-ov-file#supported-version-syntax
