### PR TITLE
Pin JRuby at 9.4 in CI matrix temporarily

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - jruby
+          - jruby-9.4
           - 2.4.10
           - 2.5.9
           - 2.6.10


### PR DESCRIPTION
JRuby 10.0.0.0 doesn't work with mongo gem for now.
https://jira.mongodb.org/browse/RUBY-3650
